### PR TITLE
Edit connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,13 @@ MIT © [Electron React Boilerplate](https://github.com/electron-react-boilerplat
   - Reload Script [docs](https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts)
   - IPC Renderer [Documentation](https://www.electronjs.org/docs/latest/api/ipc-renderer)
   - IPC two way usage [docs](https://www.electronjs.org/docs/latest/tutorial/ipc#pattern-2-renderer-to-main-two-way)
+
+## IPC Renderer
+
+In order to make sure your backend function can be used by the frontend, change these files:
+
+```
+src/main/ipc.ts
+src/main/preload.ts
+src/renderer/preload.d.ts
+```

--- a/src/db/Models.ts
+++ b/src/db/Models.ts
@@ -1,5 +1,21 @@
 /* eslint-disable import/no-cycle */
-import ConnectionEntity from './entity/ConnectionEntity';
+export type ConnectionModelType = {
+  id: number;
+
+  nickname: string;
+
+  address: string;
+
+  port: number;
+
+  username: string;
+
+  password: string;
+
+  createdDate: Date;
+
+  lastUsed: Date;
+};
 
 export class ConnectionModel {
   id: number;
@@ -18,7 +34,7 @@ export class ConnectionModel {
 
   lastUsed: Date;
 
-  constructor(entity?: ConnectionEntity) {
+  constructor(entity?: ConnectionModelType) {
     Object.assign(this, entity);
   }
 }

--- a/src/db/entity/ConnectionEntity.ts
+++ b/src/db/entity/ConnectionEntity.ts
@@ -4,7 +4,7 @@ import {
   Column,
   CreateDateColumn,
 } from 'typeorm';
-import { ConnectionModel } from '../Models';
+import { ConnectionModelType } from '../Models';
 
 @Entity({ name: 'Connection' })
 class ConnectionEntity {
@@ -32,7 +32,7 @@ class ConnectionEntity {
   @Column('datetime')
   lastUsed: Date;
 
-  constructor(model?: ConnectionModel) {
+  constructor(model?: ConnectionModelType) {
     Object.assign(this, model);
   }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -31,3 +31,7 @@ ipcMain.handle('connections:create', (_event, ...args) => {
 ipcMain.handle('connections:select', (_event, ...args) => {
   return new ConnectionService().select(args[0]);
 });
+
+ipcMain.handle('connections:update', (_event, ...args) => {
+  return new ConnectionService().update(args[0]);
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,11 +12,11 @@ import path from 'path';
 import { app, BrowserWindow, shell } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
-import AppDataSource from '../data-source';
-import MenuBuilder from './menu';
-import { resolveHtmlPath } from './util';
 import 'reflect-metadata';
 import './ipc';
+import AppDataSource from '../data-source';
+import { resolveHtmlPath } from './util';
+import MenuBuilder from './menu';
 
 class AppUpdater {
   constructor() {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
-import { ConnectionModel } from '../db/Models';
+import { ConnectionModelType } from '../db/Models';
 
 export type Channels = 'ipc-example';
 
@@ -33,8 +33,10 @@ contextBridge.exposeInMainWorld('procedures', {
 contextBridge.exposeInMainWorld('connections', {
   ipcRenderer: {
     fetch: () => ipcRenderer.invoke('connections:fetch'),
-    create: (model: ConnectionModel) =>
+    create: (model: ConnectionModelType) =>
       ipcRenderer.invoke('connections:create', model),
     select: (id: number) => ipcRenderer.invoke('connections:select', id),
+    update: (model: ConnectionModelType) =>
+      ipcRenderer.invoke('connections:update', model),
   },
 });

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -1,5 +1,6 @@
+import ConnectionEntity from 'db/entity/ConnectionEntity';
 import { Channels } from 'main/preload';
-import { ConnectionModel } from '../db/Models';
+import { ConnectionModel, ConnectionModelType } from '../db/Models';
 
 declare global {
   interface Window {
@@ -23,8 +24,9 @@ declare global {
     connections: {
       ipcRenderer: {
         fetch(): Promise<ConnectionModel[]>;
-        create(model: ConnectionModel): Promise<ConnectionModel>;
-        select(id: number): null;
+        create(model: ConnectionModelType): Promise<ConnectionModel>;
+        select(id: number): Promise<ConnectionEntity>;
+        update(model: ConnectionModelType): Promise<void>;
       };
     };
   }


### PR DESCRIPTION
Closes #56 

Adds the ability to edit an existing connection. Improves typing for the ConnectionModel Class, so that there is no circular dependency between ConnectionModel and ConnectionEntity.

Test to see if model is updated:
<img width="1792" alt="Screen Shot 2022-09-18 at 12 31 11 AM" src="https://user-images.githubusercontent.com/39541123/190918425-6ab30eb2-36e8-4461-9cf5-3ba10684a8ae.png">
