### PR TITLE
fix procedure dropdown key and db object creation

### DIFF
--- a/src/renderer/components/ProcedureDropdown.tsx
+++ b/src/renderer/components/ProcedureDropdown.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react';
 import { Dropdown } from 'react-bootstrap';
-import { ConnectionModel } from '../../db/Models';
-import DBProvider from '../../db/entity/enum';
 
 interface IProcedureDropdownProps {
   setCode: (code: string) => void;
@@ -17,18 +15,6 @@ const ProcedureDropdown = ({ setCode }: IProcedureDropdownProps) => {
 
   useEffect(() => {
     const fetchProcs = async () => {
-      const model = new ConnectionModel({
-        type: DBProvider.PostgreSQL,
-        nickname: 'something_dumb',
-        connectionConfig: {
-          config: 'manual',
-          username: 'kpmg',
-          password: 'asdf',
-          address: 'localhost',
-          port: 5432,
-        },
-      });
-      await window.connections.ipcRenderer.create(model);
       const newProcs = await window.procedures.ipcRenderer.fetchProcedures();
       setProcedures(newProcs.get('React'));
     };
@@ -47,8 +33,9 @@ const ProcedureDropdown = ({ setCode }: IProcedureDropdownProps) => {
 
       <Dropdown.Menu onClick={() => setFetch(true)}>
         {(procedures || proceduresDefault).map((procedure: string) => {
+          const procKey = `procedure- + ${procedure}`;
           return (
-            <Dropdown.Item onClick={() => handleClick(procedure)}>
+            <Dropdown.Item key={procKey} onClick={() => handleClick(procedure)}>
               {procedure}
             </Dropdown.Item>
           );


### PR DESCRIPTION
# Description
This fixes the key error printed in the console when procedure dropdown was rendered and removes repetitive code to establish a DB template before fetching procedures


## Link to the issue you are closing

Fixes #77 

## Screenshot or other testing that you have completed
![image](https://user-images.githubusercontent.com/21016565/192918818-4e813015-b995-471c-8f8f-49407b331f6a.png)


# Checklist:

- [X] ESLint passes
- [X] Prettier passes
- [X] Included comments where necessary
- [X] Updated README if needed
- [X] Verified that code runs and generates no errors/warnings
