### PR TITLE
Change database

### DIFF
--- a/src/db/PgClient.ts
+++ b/src/db/PgClient.ts
@@ -1,7 +1,7 @@
 import { Pool } from 'pg';
 import log from 'electron-log';
 import { ConnectionModelType } from './Models';
-import ServerConnectionInterface from './ServerInterface';
+import ServerInterface from './ServerInterface';
 import { ProcedureParameter, Direction } from './Procedures';
 
 type DBQuery = {
@@ -20,15 +20,16 @@ export type DBParameter = {
   arg: string;
 };
 
-export default class PgClient implements ServerConnectionInterface {
-  constructor(model: ConnectionModelType) {
+export default class PgClient implements ServerInterface {
+  constructor(model: ConnectionModelType, database?: string) {
+    this.model = model;
     if (model.connectionConfig.config === 'manual') {
       this.pool = new Pool({
         host: model.connectionConfig.address,
         port: model.connectionConfig.port,
         password: model.connectionConfig.password,
         user: model.connectionConfig.username,
-        database: 'React',
+        database: database ?? 'React',
       });
     } else {
       this.pool = new Pool({
@@ -38,6 +39,20 @@ export default class PgClient implements ServerConnectionInterface {
   }
 
   pool: Pool;
+
+  model: ConnectionModelType;
+
+  public async verify(): Promise<boolean> {
+    let client;
+    try {
+      client = await this.pool.connect();
+    } catch {
+      log.warn('Error connecting to database');
+      return false;
+    }
+    client.release();
+    return true;
+  }
 
   public async getDatabasesQuery(): Promise<unknown> {
     const client = await this.pool.connect();
@@ -60,7 +75,7 @@ export default class PgClient implements ServerConnectionInterface {
     client.release();
     return Promise.all(
       result.rows.map((row: DBProcedure) => {
-        log.verbose(row.routine_name);
+        log.silly(row.routine_name);
         return row.routine_name;
       })
     );

--- a/src/db/ServerInterface.ts
+++ b/src/db/ServerInterface.ts
@@ -1,8 +1,13 @@
 import { Pool } from 'pg';
+import { ConnectionModelType } from './Models';
 import { ProcedureParameter } from './Procedures';
 
 export default interface ServerInterface {
   pool: Pool;
+
+  model: ConnectionModelType;
+
+  verify(): Promise<boolean>;
 
   getDatabasesQuery(): Promise<unknown>;
 

--- a/src/db/redux/ServerConnections/ServerConnection.ts
+++ b/src/db/redux/ServerConnections/ServerConnection.ts
@@ -40,6 +40,7 @@ export const serverConnectionSlice = createSlice({
       state.valid = false;
     },
     setDB: (state, action: PayloadAction<string>) => {
+      state.valid = true;
       state.serverConnection = new PgClient(
         state.serverConnection.model,
         action.payload

--- a/src/db/redux/ServerConnections/ServerConnection.ts
+++ b/src/db/redux/ServerConnections/ServerConnection.ts
@@ -39,10 +39,16 @@ export const serverConnectionSlice = createSlice({
     clear: (state) => {
       state.valid = false;
     },
+    setDB: (state, action: PayloadAction<string>) => {
+      state.serverConnection = new PgClient(
+        state.serverConnection.model,
+        action.payload
+      ) as ServerInterface;
+    },
   },
 });
 
-export const { change, clear } = serverConnectionSlice.actions;
+export const { change, clear, setDB } = serverConnectionSlice.actions;
 
 export const selectServerConnection = (state: RootState) =>
   state.connection.serverConnection;

--- a/src/db/service/ConnectionService.ts
+++ b/src/db/service/ConnectionService.ts
@@ -68,10 +68,17 @@ export default class ConnectionService {
 
   public async switch(database: string): Promise<boolean> {
     store.dispatch(setDB(database)); // TODO instantiate based on model.type
-    if (!(await store.getState().connection.serverConnection.verify())) {
+    if (!(await this.verify())) {
       store.dispatch(clear());
       return false;
     }
     return true;
+  }
+
+  public async verify(): Promise<boolean> {
+    // Check if the current connection is marked valid and works
+    return store.getState().connection.valid
+      ? store.getState().connection.serverConnection.verify()
+      : false;
   }
 }

--- a/src/db/service/ConnectionService.ts
+++ b/src/db/service/ConnectionService.ts
@@ -1,6 +1,10 @@
 import { Repository } from 'typeorm';
 import log from 'electron-log';
-import { clear, change } from '../redux/ServerConnections/ServerConnection';
+import {
+  clear,
+  change,
+  setDB,
+} from '../redux/ServerConnections/ServerConnection';
 import { store } from '../redux/store';
 import PgClient from '../PgClient';
 import AppDataSource from '../../data-source';
@@ -31,7 +35,7 @@ export default class ConnectionService {
     const entity = await this.repository.findOneBy({ id });
     if (entity !== null) {
       entity.lastUsed = new Date();
-      store.dispatch(change(new PgClient(new ConnectionModel(entity))));
+      store.dispatch(change(new PgClient(new ConnectionModel(entity)))); // TODO instantiate based on model.type
       return this.repository.save(entity);
     }
     return new ConnectionEntity();
@@ -60,5 +64,14 @@ export default class ConnectionService {
       entity.lastUsed = new Date();
       await this.repository.save(entity);
     }
+  }
+
+  public async switch(database: string): Promise<boolean> {
+    store.dispatch(setDB(database)); // TODO instantiate based on model.type
+    if (!(await store.getState().connection.serverConnection.verify())) {
+      store.dispatch(clear());
+      return false;
+    }
+    return true;
   }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -47,3 +47,7 @@ ipcMain.handle('connections:update', (_event, ...args) => {
 ipcMain.handle('connections:switch', (_event, ...args) => {
   return new ConnectionService().switch(args[0]);
 });
+
+ipcMain.handle('connections:verify', (_event) => {
+  return new ConnectionService().verify();
+});

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -43,3 +43,7 @@ ipcMain.handle('connections:disconnect', (_event) => {
 ipcMain.handle('connections:update', (_event, ...args) => {
   return new ConnectionService().update(args[0]);
 });
+
+ipcMain.handle('connections:switch', (_event, ...args) => {
+  return new ConnectionService().switch(args[0]);
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,33 +11,16 @@
 import path from 'path';
 import { app, BrowserWindow, shell } from 'electron';
 import { autoUpdater } from 'electron-updater';
-import log, { LogMessage } from 'electron-log';
+import log from 'electron-log';
 import 'reflect-metadata';
 import './ipc';
-import chalk from 'chalk';
 import AppDataSource from '../data-source';
-import { resolveHtmlPath, getDataPath } from './util';
+import { resolveHtmlPath, setLog } from './util';
 import MenuBuilder from './menu';
 
 class AppUpdater {
   constructor() {
-    log.transports.file.resolvePath = () =>
-      path.join(getDataPath(), 'logs/main.log');
-    log.transports.file.level = 'info';
-    log.transports.console.format = (message: LogMessage, _data: unknown) => {
-      const str = `[${message.date.toUTCString()}] ${`[${message.level}]`.padEnd(
-        9,
-        ' '
-      )} `;
-      if (message.level === 'error') return chalk.bgRed(str) + message.data;
-      if (message.level === 'warn') return chalk.red(str) + message.data;
-      if (message.level === 'info') return chalk.cyan(str) + message.data;
-      if (message.level === 'debug') return chalk.green(str) + message.data;
-      if (message.level === 'verbose') return chalk.bgBlack(str) + message.data;
-      return chalk.white(str);
-    };
-    log.transports.console.useStyles = true;
-
+    setLog();
     autoUpdater.logger = log;
     autoUpdater.checkForUpdatesAndNotify();
   }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -44,5 +44,7 @@ contextBridge.exposeInMainWorld('connections', {
     disconnect: () => ipcRenderer.invoke('connections:disconnect'),
     update: (model: ConnectionModelType) =>
       ipcRenderer.invoke('connections:update', model),
+    switch: (database: string) =>
+      ipcRenderer.invoke('connections:switch', database),
   },
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -46,5 +46,6 @@ contextBridge.exposeInMainWorld('connections', {
       ipcRenderer.invoke('connections:update', model),
     switch: (database: string) =>
       ipcRenderer.invoke('connections:switch', database),
+    verify: () => ipcRenderer.invoke('connections:verify'),
   },
 });

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -2,6 +2,8 @@
 import { URL } from 'url';
 import path from 'path';
 import { app } from 'electron';
+import log, { LogMessage } from 'electron-log';
+import chalk from 'chalk';
 
 export function resolveHtmlPath(htmlFileName: string) {
   if (process.env.NODE_ENV === 'development') {
@@ -15,4 +17,25 @@ export function resolveHtmlPath(htmlFileName: string) {
 
 export function getDataPath() {
   return process.env.NODE_ENV === 'development' ? '.' : app.getPath('userData');
+}
+
+export function setLog() {
+  log.transports.file.resolvePath = () =>
+    path.join(getDataPath(), 'logs/main.log');
+  log.transports.file.level =
+    process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+  log.transports.console.level = 'debug';
+  log.transports.console.format = (message: LogMessage, _data: unknown) => {
+    const str = `[${message.date.toUTCString()}] ${`[${message.level}]`.padEnd(
+      9,
+      ' '
+    )} `;
+    if (message.level === 'error') return chalk.bgRed(str) + message.data;
+    if (message.level === 'warn') return chalk.red(str) + message.data;
+    if (message.level === 'info') return chalk.cyan(str) + message.data;
+    if (message.level === 'debug') return chalk.green(str) + message.data;
+    if (message.level === 'verbose') return chalk.bgBlack(str) + message.data;
+    return chalk.white(str);
+  };
+  log.transports.console.useStyles = true;
 }

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -32,6 +32,7 @@ declare global {
         delete(id: number): Promise<void>;
         disconnect(): Promise<void>;
         switch(database: string): Promise<boolean>;
+        preload(): Promise<boolean>;
       };
     };
   }

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -31,6 +31,7 @@ declare global {
         update(model: ConnectionModelType): Promise<void>;
         delete(id: number): Promise<void>;
         disconnect(): Promise<void>;
+        switch(database: string): Promise<boolean>;
       };
     };
   }


### PR DESCRIPTION
# Description

Minor tweak to logging. I moved the log setup to the `util.ts` file with a `setLog` function that can be used to initialize it anywhere. This is useful for debugging one class at a time.

Created the method to swap the active client with a new one pointed at the desired procedure. There is also a new `verify` method to easily check if a connection is valid.

## Link to the issue you are closing

Fixes #82 

## Screenshot or other testing that you have completed

```ts
public async test() {
    setLog();
    await AppDataSource.initialize();
    const model = new ConnectionModel({
      type: DBProvider.PostgreSQL,
      nickname: 'something_dumb',
      connectionConfig: {
        config: 'manual',
        username: 'kpmg',
        password: 'asdf',
        address: 'localhost',
        port: 5432,
      },
    });
    this.create(model);
    const proc = new Procedures();
    log.debug('Databases on server: ', await proc.getDatabases());
    log.debug(
      JSON.stringify(
        Array.from((await proc.getProceduresForDB(['React'])).entries())
      )
    );

    log.debug('Switching to "Saless". Valid?: ', await this.switch('Saless'));
    log.debug('Switching to "Sales". Valid?: ', await this.switch('Sales'));
    log.debug(
      JSON.stringify(
        Array.from((await proc.getProceduresForDB(['Sales'])).entries())
      )
    );
  }
```

```bash
[2022-09-29 03:13:48.661] [debug] Databases on server:  [ 'postgres', 'jid', 'adityavidyadharan', 'Sales', 'React' ]
[2022-09-29 03:13:48.672] [debug] [["React",["transfer2","transfer3","transfer4","transfer6","transfer7","transfer8","transfer9","transfer10","transfer"]]]
[2022-09-29 03:13:48.684] [warn]  Error connecting to database
[2022-09-29 03:13:48.685] [debug] Switching to "Saless". Valid?:  false
[2022-09-29 03:13:48.693] [debug] Switching to "Sales". Valid?:  true
[2022-09-29 03:13:48.700] [debug] [["Sales",["transfer","transfer2"]]]
```

# Checklist:

- [x] ESLint passes
- [x] Prettier passes
- [x] Included comments where necessary
- [x] Updated README if needed
- [x] Verified that code runs and generates no errors/warnings
