### PR TITLE
Use color palette

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,8 @@
 import { HashRouter as Router, Routes, Route } from 'react-router-dom';
-import './scss/App.scss';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
+import './scss/App.scss';
+
 import Execute from './components/Execute';
 import Home from './components/Home';
 import NewConnections from './components/NewConnections';

--- a/src/renderer/components/Execute.tsx
+++ b/src/renderer/components/Execute.tsx
@@ -23,31 +23,32 @@ const Execute = () => {
   };
 
   return (
-    <div>
-      <h1>Execute Stored Procedures</h1>
-      <div>
-        <h6>Selected Database</h6>
-        <DBDropdown activeDb={activeDb} updateDb={updateDb} />
-      </div>
-      <div>
-        <h6>Selected Procedure</h6>
-        <ProcedureDropdown
-          activeDb={activeDb}
-          activeProcedure={activeProcedure}
-          setActiveProcedure={setActiveProcedure}
-          setCode={setCode}
-        />
-      </div>
+    <div className="d-flex justify-content-center align-items-center">
       <div className="execute-wrapper">
-        <p className="procedure-code">{code}</p>
-      </div>
-      <div className="home-btn-footer">
-        <Link to="/">
-          <Button className="home-button">Home</Button>
-          <Button onClick={() => handleClick()} className="disconnect-button">
-            Disconnect
-          </Button>
-        </Link>
+        <h1>Execute Stored Procedures</h1>
+        <div>
+          <h6>Selected Database</h6>
+          <DBDropdown activeDb={activeDb} updateDb={updateDb} />
+        </div>
+        <div>
+          <h6>Selected Procedure</h6>
+          <ProcedureDropdown
+            activeDb={activeDb}
+            activeProcedure={activeProcedure}
+            setActiveProcedure={setActiveProcedure}
+            setCode={setCode}
+          />
+        </div>
+        <div className="code-wrapper">
+          <p className="procedure-code">{code}</p>
+        </div>
+        <div className="home-btn-footer">
+          <Link to="/">
+            <Button onClick={() => handleClick()} className="home-btn">
+              Disconnect
+            </Button>
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/components/NewConnectionForm.tsx
+++ b/src/renderer/components/NewConnectionForm.tsx
@@ -163,7 +163,7 @@ const NewConnectionForm = () => {
   return (
     <div>
       <div className="d-flex justify-content-center">
-        <Form className="new-connection-form" onSubmit={(e) => handleSubmit(e)}>
+        <Form className="new-conn-form" onSubmit={(e) => handleSubmit(e)}>
           <Form.Group className="mb-2" controlId="connectionNickname">
             <Form.Label className="form-label-sm">Nickname</Form.Label>
             <Form.Control

--- a/src/renderer/components/NewConnections.tsx
+++ b/src/renderer/components/NewConnections.tsx
@@ -6,15 +6,17 @@ import '../scss/NewConnection.scss';
 
 const NewConnections = () => {
   return (
-    <>
-      <h1> Create New Connection</h1>
-      <NewConnectionForm />
-      <div className="home-btn-footer">
-        <Link to="/">
-          <Button className="home-btn">Home</Button>
-        </Link>
+    <div className="d-flex justify-content-center align-items-center">
+      <div className="new-conn-wrapper">
+        <h1 className="new-conn-header"> Create New Connection</h1>
+        <NewConnectionForm />
+        <div className="home-btn-footer">
+          <Link to="/">
+            <Button className="home-btn">Home</Button>
+          </Link>
+        </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/renderer/components/RecentConnections.tsx
+++ b/src/renderer/components/RecentConnections.tsx
@@ -1,10 +1,11 @@
-import '../scss/RecentConnections.scss';
 import { Link } from 'react-router-dom';
 import { Button, Table } from 'react-bootstrap';
 import { useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import { ConnectionModel } from '../../db/Models';
+
+import '../scss/RecentConnections.scss';
 
 const RecentConnections = () => {
   const [connect, setConnect] = useState<ConnectionModel[]>([]);
@@ -27,60 +28,62 @@ const RecentConnections = () => {
     connect.shift();
   }
   return (
-    <div className="RecentWrapper">
-      <h1 className="Header">Recent Connections</h1>
-      <div className="TDiv">
-        <Table className="table">
-          <thead>
-            <tr>
-              <th>Nick Name</th>
-              <th>Database Type</th>
-              <th>Address</th>
-              <th>Port</th>
-              <th>User Name</th>
-              <th>Delete</th>
-            </tr>
-          </thead>
-          <tbody>
-            {connect.map((value) => {
-              if (value.connectionConfig.config === 'manual') {
-                return (
-                  <tr key={value.id}>
-                    <td className="LinkTD">
-                      <Link to="/Execute">
-                        <button
-                          className="buttonSelect"
-                          type="button"
-                          onClick={() => handleSelect(value.id)}
-                        >
-                          {value.nickname}
+    <div className="d-flex justify-content-center align-items-center">
+      <div className="recent-wrapper">
+        <h1>Recent Connections</h1>
+        <div className="d-flex justify-content-center">
+          <Table className="table">
+            <thead>
+              <tr>
+                <th>Nick Name</th>
+                <th>Database Type</th>
+                <th>Address</th>
+                <th>Port</th>
+                <th>User Name</th>
+                <th>Delete</th>
+              </tr>
+            </thead>
+            <tbody>
+              {connect.map((value) => {
+                if (value.connectionConfig.config === 'manual') {
+                  return (
+                    <tr key={value.id}>
+                      <td>
+                        <Link to="/Execute">
+                          <button
+                            className="buttonSelect"
+                            type="button"
+                            onClick={() => handleSelect(value.id)}
+                          >
+                            {value.nickname}
+                          </button>
+                        </Link>
+                      </td>
+                      <td>{value.type}</td>
+                      <td>{value.connectionConfig.address}</td>
+                      <td>{value.connectionConfig.port}</td>
+                      <td>{value.connectionConfig.username}</td>
+                      <td>
+                        <button type="button" className="deleteButton">
+                          <FontAwesomeIcon
+                            icon={faTrashAlt}
+                            onClick={() => handledelete(value.id)}
+                          />
                         </button>
-                      </Link>
-                    </td>
-                    <td>{value.type}</td>
-                    <td>{value.connectionConfig.address}</td>
-                    <td>{value.connectionConfig.port}</td>
-                    <td>{value.connectionConfig.username}</td>
-                    <td>
-                      <button type="button" className="deleteButton">
-                        <FontAwesomeIcon
-                          icon={faTrashAlt}
-                          onClick={() => handledelete(value.id)}
-                        />
-                      </button>
-                    </td>
-                  </tr>
-                );
-              }
-              return null;
-            })}
-          </tbody>
-        </Table>
-      </div>
-      <div className="toHome">
-        <Link to="/" className="link">
-          <Button className="HomeButton">Home</Button>
-        </Link>
+                      </td>
+                    </tr>
+                  );
+                }
+                return null;
+              })}
+            </tbody>
+          </Table>
+        </div>
+        <div className="home-btn-footer">
+          <Link to="/" className="link">
+            <Button className="home-btn">Home</Button>
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/scss/App.scss
+++ b/src/renderer/scss/App.scss
@@ -1,16 +1,12 @@
+@use './utils/button-variants.scss';
+@use './utils/colors.scss';
+
 body {
   position: relative;
-  color: black;
-  background: white;
+  color: colors.$jet;
+  background: colors.$persian-green;
   font-family: sans-serif;
   overflow-y: hidden;
-
-  --eerie-black: #131515ff;
-  --jet: #2b2c28ff;
-  --persian-green: #339989ff;
-  --middle-blue-green: #7de2d1ff;
-  --snow: #fffafbff;
-  --sand: #e4c3ad;
 }
 
 .centered {
@@ -21,9 +17,19 @@ body {
 
 .home-btn-footer {
   float: right;
+  margin-bottom: 20px;
 }
 
 .home-btn {
   margin: 5px;
   margin-right: 10vw;
+}
+
+.btn-primary {
+  @include button-variants.bootstrap-button(colors.$middle-blue-green);
+}
+
+h1 {
+  margin-top: 10px;
+  text-align: center;
 }

--- a/src/renderer/scss/Execute.scss
+++ b/src/renderer/scss/Execute.scss
@@ -1,6 +1,15 @@
+@use './utils/colors.scss';
+
 .execute-wrapper {
-  height: 60vh;
-  width: 100vw;
+  background-color: colors.$snow;
+  color: colors.$jet;
+  width: 90vw;
+  height: auto;
+}
+
+.code-wrapper {
+  height: auto;
+  min-height: 40vw;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -9,6 +18,7 @@
 
 .dropdown button {
   margin: 5px;
+  margin-left: 10vw;
   min-width: 5em;
 }
 
@@ -17,5 +27,5 @@
 }
 
 h6 {
-  margin: 5px;
+  margin-left: 10vw;
 }

--- a/src/renderer/scss/Execute.scss
+++ b/src/renderer/scss/Execute.scss
@@ -5,6 +5,7 @@
   color: colors.$jet;
   width: 90vw;
   height: auto;
+  border-radius: 0.375em;
 }
 
 .code-wrapper {

--- a/src/renderer/scss/Home.scss
+++ b/src/renderer/scss/Home.scss
@@ -1,10 +1,12 @@
+@use './utils/colors.scss';
+
 .home {
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color: var(--persian-green);
-  color: var(--snow);
+  background-color: colors.$persian-green;
+  color: colors.$snow;
 
   .menu-wrapper {
     display: flex;
@@ -17,7 +19,7 @@
       flex-direction: column;
       width: 40vw;
       height: 100vh;
-      background-color: var(--jet);
+      background-color: colors.$jet;
 
       .recent-list {
         display: flex;
@@ -25,20 +27,23 @@
         padding: 10px 30px;
         overflow: hidden;
 
+        hr {
+          color: colors.$snow;
+        }
         .recent-item {
           cursor: pointer;
           transition: none;
           stroke: none;
           text-align: left;
           background-color: inherit;
-          color: inherit;
+          color: colors.$snow;
           border: none;
           width: 100%;
           padding: 5px 0px;
 
           .recent-item-info {
             font-size: 12px;
-            color: var(--sand);
+            color: colors.$sand;
             overflow: hidden;
           }
           & span {
@@ -77,10 +82,6 @@ h4 {
   font-weight: 400;
 }
 
-h1 {
-  margin: 5px;
-}
-
 .icon {
   margin: 5px;
   vertical-align: middle;
@@ -94,7 +95,7 @@ h1 {
   margin: 5px;
   transition: none;
   stroke: none;
-  color: var(--snow);
+  color: colors.$snow;
   background-color: #00000000;
   width: calc(50vw - 10px);
   box-shadow: none;
@@ -102,11 +103,5 @@ h1 {
 
 .launch-button:hover {
   transform: none;
-}
-
-.execute-button {
-  margin: 1vw;
-  position: absolute;
-  right: 5%;
-  bottom: 5%;
+  color: colors.$jet;
 }

--- a/src/renderer/scss/NewConnection.scss
+++ b/src/renderer/scss/NewConnection.scss
@@ -1,4 +1,18 @@
-.new-connection-form {
+@use './utils/colors.scss';
+
+.new-conn-form {
   padding: 10px;
   width: 80%;
+  display: block;
+}
+
+.new-conn-wrapper {
+  background-color: colors.$snow;
+  color: colors.$jet;
+  width: 90vw;
+  height: auto;
+}
+
+.new-conn-header {
+  margin-top: 10px;
 }

--- a/src/renderer/scss/NewConnection.scss
+++ b/src/renderer/scss/NewConnection.scss
@@ -11,6 +11,7 @@
   color: colors.$jet;
   width: 90vw;
   height: auto;
+  border-radius: 0.375em;
 }
 
 .new-conn-header {

--- a/src/renderer/scss/RecentConnections.scss
+++ b/src/renderer/scss/RecentConnections.scss
@@ -1,22 +1,20 @@
-h1 {
-  text-align: center;
-  margin: auto;
+@use './utils/colors.scss';
+
+.recent-wrapper {
+  background-color: colors.$snow;
+  color: colors.$jet;
+  width: 90vw;
+  height: auto;
+  overflow: hidden;
 }
 
-.RecentWrapper {
-  display: grid;
-  grid-template-rows: repeat(3, 1fr);
-  grid-column: span;
-}
-
-.TDiv {
-  margin: auto;
-}
 .table {
   text-align: center;
+  width: 80%;
 }
+
 thead {
-  background-color: lightgrey;
+  background-color: colors.$sand;
 }
 
 th {
@@ -32,9 +30,6 @@ tr {
 
 td {
   border: 3px solid;
-}
-.LinkTD {
-  border: none;
 }
 
 .deleteButton,
@@ -56,14 +51,4 @@ td {
 
 .deleteButton:hover {
   background-color: rgb(247, 68, 68);
-}
-
-.toHome {
-  justify-self: end;
-}
-
-.HomeButton {
-  margin: 5px;
-  margin-right: 10vw;
-  justify-self: end;
 }

--- a/src/renderer/scss/RecentConnections.scss
+++ b/src/renderer/scss/RecentConnections.scss
@@ -6,6 +6,7 @@
   width: 90vw;
   height: auto;
   overflow: hidden;
+  border-radius: 0.375em;
 }
 
 .table {

--- a/src/renderer/scss/utils/button-variants.scss
+++ b/src/renderer/scss/utils/button-variants.scss
@@ -1,0 +1,64 @@
+@mixin button-variant($color, $background, $border) {
+  color: $color;
+  background-color: $background;
+  border-color: $border;
+  &:focus,
+  &.focus {
+    color: $color;
+    background-color: darken($background, 10%);
+    border-color: darken($border, 25%);
+  }
+  &:hover {
+    color: $color;
+    background-color: darken($background, 10%);
+    border-color: darken($border, 12%);
+  }
+  &:active,
+  &.active,
+  .open > &.dropdown-toggle {
+    color: $color;
+    background-color: darken($background, 10%);
+    border-color: darken($border, 12%);
+
+    &:hover,
+    &:focus,
+    &.focus {
+      color: $color;
+      background-color: darken($background, 17%);
+      border-color: darken($border, 25%);
+    }
+  }
+  &:active,
+  &.active,
+  .open > &.dropdown-toggle {
+    background-image: none;
+  }
+  &.disabled,
+  &[disabled],
+  fieldset[disabled] & {
+    &,
+    &:hover,
+    &:focus,
+    &.focus,
+    &:active,
+    &.active {
+      background-color: $background;
+      border-color: $border;
+    }
+  }
+  .badge {
+    color: $background;
+    background-color: $color;
+  }
+}
+
+// Mixin to create a bootstrap button with custom colors
+@mixin bootstrap-button($background) {
+  $color: #fff;
+  $border: 5%;
+  @if (lightness($background) >= lightness(#aaa)) {
+    $color: #333;
+    $border: 0.2 * lightness($background);
+  }
+  @include button-variant($color, $background, darken($background, $border));
+}

--- a/src/renderer/scss/utils/colors.scss
+++ b/src/renderer/scss/utils/colors.scss
@@ -1,0 +1,6 @@
+$eerie-black: #131515ff;
+$jet: #2b2c28ff;
+$persian-green: #339989ff;
+$middle-blue-green: #7de2d1ff;
+$snow: #fffafbff;
+$sand: #e4c3ad;


### PR DESCRIPTION
# Description

This PR was needed to update the entire app to match the style changes introduced in #49. 

** The diff is large because I wrapped a lot of components in flex divs in order to center things

- Each page's content is centered in a white box on a green background
- Buttons and dropdowns use theme colors
- Removed extra 'Home' button on Execute screen
- The formatting doesn't immediately break when you resize the window
- Divs use responsive heights + handle overflow

Also introduces a lot of .scss cleanup and QOL improvements:
- mixin for custom buttons
- defined colors as variables in their own file
- removed unnecessary css classes + condensed common classes into App.scss

## Link to the issue you are closing

Fixes #104 

## Screenshot or other testing that you have completed


https://user-images.githubusercontent.com/29695042/193440612-0434869d-da97-4041-a1c9-4f58901620a2.mov



# Checklist:

- [x] ESLint passes
- [x] Prettier passes
- [x] Included comments where necessary
- [x] Updated README if needed
- [x] Verified that code runs and generates no errors/warnings
