### PR TITLE
edit form refresh recent connections immediately

### DIFF
--- a/src/renderer/components/EditForm.tsx
+++ b/src/renderer/components/EditForm.tsx
@@ -2,33 +2,22 @@
 
 import React, { useEffect, useState } from 'react';
 import { Button, Form, Modal } from 'react-bootstrap';
-import {
-  ConnectionModel,
-  ConnectionModelType,
-  ConnectionString,
-  ManualConnectionConfig,
-} from '../../db/Models';
+import { ConnectionModel } from '../../db/Models';
 import DBProvider from '../../db/entity/enum';
 import '../scss/RecentConnections.scss';
 
 interface IEditProps {
   config: ConnectionModel;
+  setConnect: () => void;
 }
 
 interface IEditFields {
   nickname: string;
-  type: DBProvider;
-  address?: string;
-  port?: number;
-  username?: string;
-  password?: string;
-  connectionString?: string;
 }
 
-const EditForm = ({ config }: IEditProps) => {
+const EditForm = ({ config, setConnect }: IEditProps) => {
   const [form, setForm] = useState<IEditFields>({
     nickname: config.nickname,
-    type: config.type,
   });
 
   const [show, setShow] = useState<boolean>(false);
@@ -36,48 +25,17 @@ const EditForm = ({ config }: IEditProps) => {
   const handleShow = () => setShow(true);
 
   useEffect(() => {
-    if (config.connectionConfig.config === 'manual') {
-      setForm({
-        ...form,
-        address: config.connectionConfig.address,
-        port: config.connectionConfig.port,
-        username: config.connectionConfig.username,
-        password: config.connectionConfig.password,
-      });
-    } else {
-      setForm({
-        ...form,
-        connectionString: config.connectionConfig.connectionString,
-      });
-    }
+    setForm({
+      ...form,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    let connectionConfig: ManualConnectionConfig | ConnectionString;
-    if (form.connectionString !== undefined && form.connectionString !== '') {
-      connectionConfig = {
-        config: 'string',
-        connectionString: form.connectionString,
-      };
-    } else {
-      connectionConfig = {
-        config: 'manual',
-        address: form.address!,
-        port: form.port!,
-        username: form.username!,
-        password: form.password!,
-      };
-    }
-    const newConfig: ConnectionModelType = {
-      id: config.id,
-      nickname: form.nickname,
-      type: form.type,
-      connectionConfig,
-      createdDate: config.createdDate,
-    };
-    await window.connections.ipcRenderer.update(newConfig);
+    config.nickname = form.nickname;
+    await window.connections.ipcRenderer.update(config);
+    setConnect();
     handleClose();
   };
 
@@ -110,67 +68,6 @@ const EditForm = ({ config }: IEditProps) => {
                 placeholder="Enter Nickname"
                 value={form.nickname}
                 onChange={(e) => setField('nickname', e.target.value)}
-              />
-            </Form.Group>
-
-            <Form.Group controlId="type">
-              <Form.Label>Database Type</Form.Label>
-              <Form.Control
-                as="select"
-                value={form.type}
-                onChange={(e) => setField('type', e.target.value as DBProvider)}
-              >
-                <option value={DBProvider.PostgreSQL}>PostgreSQL</option>
-              </Form.Control>
-            </Form.Group>
-
-            <Form.Group controlId="address">
-              <Form.Label>Address</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="Enter Address"
-                value={form.address}
-                onChange={(e) => setField('address', e.target.value)}
-              />
-            </Form.Group>
-
-            <Form.Group controlId="port">
-              <Form.Label>Port</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="Enter Port"
-                value={form.port}
-                onChange={(e) => setField('port', e.target.value)}
-              />
-            </Form.Group>
-
-            <Form.Group controlId="username">
-              <Form.Label>Username</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="Enter Username"
-                value={form.username}
-                onChange={(e) => setField('username', e.target.value)}
-              />
-            </Form.Group>
-
-            <Form.Group controlId="password">
-              <Form.Label>Password</Form.Label>
-              <Form.Control
-                type="password"
-                placeholder="Enter Password"
-                value={form.password}
-                onChange={(e) => setField('password', e.target.value)}
-              />
-            </Form.Group>
-
-            <Form.Group controlId="connectionString">
-              <Form.Label>Connection String</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="Enter Connection String"
-                value={form.connectionString}
-                onChange={(e) => setField('connectionString', e.target.value)}
               />
             </Form.Group>
 

--- a/src/renderer/components/EditForm.tsx
+++ b/src/renderer/components/EditForm.tsx
@@ -2,8 +2,8 @@
 
 import React, { useEffect, useState } from 'react';
 import { Button, Form, Modal } from 'react-bootstrap';
-import { ConnectionModel } from '../../db/Models';
 import { PencilSquare } from 'react-bootstrap-icons';
+import { ConnectionModel } from '../../db/Models';
 import DBProvider from '../../db/entity/enum';
 import '../scss/RecentConnections.scss';
 
@@ -20,10 +20,9 @@ const EditForm = ({ config, setConnect }: IEditProps) => {
   const [form, setForm] = useState<IEditFields>({
     nickname: config.nickname,
   });
-  
+
   const [show, setShow] = useState<boolean>(false);
   const handleClose = () => {
-    setForm(defaultForm);
     setShow(false);
   };
   const handleShow = () => setShow(true);
@@ -74,7 +73,7 @@ const EditForm = ({ config, setConnect }: IEditProps) => {
                 onChange={(e) => setField('nickname', e.target.value)}
               />
             </Form.Group>
-            
+
             <Button variant="primary" type="submit">
               Submit
             </Button>

--- a/src/renderer/components/RecentConnections.tsx
+++ b/src/renderer/components/RecentConnections.tsx
@@ -7,11 +7,11 @@ import EditForm from './EditForm';
 
 const RecentConnections = () => {
   const [connect, setConnect] = useState<ConnectionModel[]>([]);
+  const getConnections = async () => {
+    const connections = await window.connections.ipcRenderer.fetch();
+    setConnect(connections);
+  };
   useEffect(() => {
-    const getConnections = async () => {
-      const connections = await window.connections.ipcRenderer.fetch();
-      setConnect(connections);
-    };
     getConnections();
   }, []);
 
@@ -49,7 +49,7 @@ const RecentConnections = () => {
                     <td>{value.connectionConfig.port}</td>
                     <td>{value.connectionConfig.username}</td>
                     <td>
-                      <EditForm config={value} />
+                      <EditForm config={value} setConnect={getConnections} />
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
# Description

Makes the edit form more compact by including only the nickname field
Populates the field with the existing values
Fixes issue where closing and reopening the form doesn't repopulate the field
Fixes issue where changing data causes a visible refresh effect

## Screenshot or other testing that you have completed

Your PR should include at least one test/screenshot in order to show


https://user-images.githubusercontent.com/39541123/193471985-dc52ec94-5f0f-42d3-b683-1ce7d51c80dd.mov




<img width="687" alt="Screen Shot 2022-10-02 at 3 07 28 PM" src="https://user-images.githubusercontent.com/39541123/193471725-2a9cd6cb-7af2-48d0-b5b7-982c9a2b5bb5.png">
case that the changes don't break/fix what was needed. In the case of frontend, a screenshot should suffice. For backend, depending on the scenario, some temporary tests may need to be written to show that the function does what's needed.

# Checklist:

- [x] ESLint passes
- [x] Prettier passes
- [x] Included comments where necessary
- [x] Updated README if needed
- [x] Verified that code runs and generates no errors/warnings
