### PR TITLE
Detailed Connection Error Messages

### DIFF
--- a/src/db/clients/PgClient.ts
+++ b/src/db/clients/PgClient.ts
@@ -53,9 +53,11 @@ export default class PgClient implements ServerInterface {
     let client;
     try {
       client = await this.pool.connect();
-    } catch {
-      log.warn('Error connecting to database');
-      return false;
+
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    } catch (e: any) {
+      log.warn(e.message);
+      throw new Error(e.message);
     }
     client.release();
     return true;

--- a/src/db/entity/ConnectionEntity.ts
+++ b/src/db/entity/ConnectionEntity.ts
@@ -102,7 +102,7 @@ class ConnectionEntity {
         model.type,
         model.connectionConfig.connectionString
       );
-      const { username, password, endpoint } = fields;
+      const { username, password, endpoint, options } = fields;
       if (fields.hosts.length > 0) {
         Object.assign(this, {
           config: 'manual',
@@ -111,6 +111,7 @@ class ConnectionEntity {
           password,
           address: fields.hosts[0].host,
           port: fields.hosts[0].port,
+          ssl: options && options.ssl ? options.ssl === 'true' : false,
         });
       }
     }

--- a/src/db/service/ConnectionService.ts
+++ b/src/db/service/ConnectionService.ts
@@ -53,12 +53,15 @@ export default class ConnectionService {
     const parsedEntity = new ConnectionEntity(model);
     const entity = await this.repository.save(parsedEntity);
     console.log(this.entityToModel(entity));
+
     try {
       return await this.select(entity.id);
-    } catch (e) {
+
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    } catch (e: any) {
       log.error(e);
-      this.delete(entity.id);
-      throw new Error('Connection is not valid');
+      await this.delete(entity.id);
+      throw new Error(e.message);
     }
   }
 
@@ -67,10 +70,15 @@ export default class ConnectionService {
     if (entity !== null) {
       entity.lastUsed = new Date();
       store.dispatch(change(this.entityToModel(entity)));
-      if (!(await this.verify())) {
+
+      try {
+        await this.verify();
+
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      } catch (e: any) {
         store.dispatch(clear());
-        log.error('Connection is not valid');
-        throw new Error('Connection is not valid');
+        log.error(e.message);
+        throw new Error(e.message);
       }
       return this.repository.save(entity);
     }
@@ -113,6 +121,14 @@ export default class ConnectionService {
     if (connection === undefined) {
       return false;
     }
-    return connection.verify();
+
+    try {
+      return await connection.verify();
+
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    } catch (e: any) {
+      log.error(e);
+      throw new Error(e.message);
+    }
   }
 }

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -31,7 +31,11 @@ export function parseConnectionString(
     scheme: type.toLowerCase(),
     hosts: [],
   });
-  return connectionStringParser.parse(cs);
+  let parseCs = cs;
+  if (cs.split('@').length - 1 > 1) {
+    parseCs = cs.replace('@', '%40');
+  }
+  return connectionStringParser.parse(parseCs);
 }
 
 export function setLog() {

--- a/src/renderer/components/modals/ServerConnectionErrorModal.tsx
+++ b/src/renderer/components/modals/ServerConnectionErrorModal.tsx
@@ -2,10 +2,12 @@ import Modal from '../utils/Modal';
 
 interface IServerConnectionErrorModalProps {
   show: boolean;
+  alertMsg: string;
   handleClose: () => void;
 }
 const ServerConnectionErrorModal = ({
   show,
+  alertMsg,
   handleClose,
 }: IServerConnectionErrorModalProps) => {
   return (
@@ -13,8 +15,7 @@ const ServerConnectionErrorModal = ({
       show={show}
       handleClose={handleClose}
       title="Error"
-      modalBody="Could not connect to the server. Please check your configuration
-            details."
+      modalBody={alertMsg}
     />
   );
 };

--- a/src/renderer/components/new_connections/NewConnectionForm.tsx
+++ b/src/renderer/components/new_connections/NewConnectionForm.tsx
@@ -242,7 +242,7 @@ const NewConnectionForm = () => {
                   value={form.database}
                   onChange={(e) => setField('database', e.target.value)}
                   type="text"
-                  placeholder="Ex: React"
+                  placeholder="Ex: postgres"
                   isInvalid={!!errors.database}
                 />
                 <Form.Control.Feedback type="invalid">

--- a/src/renderer/components/new_connections/NewConnectionForm.tsx
+++ b/src/renderer/components/new_connections/NewConnectionForm.tsx
@@ -277,6 +277,13 @@ const NewConnectionForm = () => {
                   {errors.password}
                 </Form.Control.Feedback>
               </Form.Group>
+              <Form.Group className="mb-2" controlId="formBasicCheckbox">
+                <Form.Check
+                  onChange={() => setField('ssl', !form.ssl)}
+                  type="checkbox"
+                  label="SSL"
+                />
+              </Form.Group>
             </>
           )}
           {connectionStringActive && (
@@ -287,7 +294,7 @@ const NewConnectionForm = () => {
                 value={form.connectionString}
                 onChange={(e) => setField('connectionString', e.target.value)}
                 type="text"
-                placeholder="Ex: postgresql://username:password@address:port/db"
+                placeholder="Ex: postgresql://<username>:<password>@<address>:<port>/<database>?ssl=true"
                 isInvalid={!!errors.connectionString}
                 as="textarea"
                 rows={3}
@@ -297,13 +304,6 @@ const NewConnectionForm = () => {
               </Form.Control.Feedback>
             </Form.Group>
           )}
-          <Form.Group className="mb-2" controlId="formBasicCheckbox">
-            <Form.Check
-              onChange={() => setField('ssl', !form.ssl)}
-              type="checkbox"
-              label="SSL"
-            />
-          </Form.Group>
           <Row>
             <Col>
               <Button variant="primary" type="submit" disabled={isConnecting}>

--- a/src/renderer/components/new_connections/NewConnectionForm.tsx
+++ b/src/renderer/components/new_connections/NewConnectionForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../db/models/ConnectionModels';
 import { DBProvider } from '../../../db/entity/enum';
 import ServerConnectionErrorModal from '../modals/ServerConnectionErrorModal';
+import { parseErrorMessage } from '../utils/helpers';
 
 interface INewConnectionForm {
   nickname: string;
@@ -44,8 +45,10 @@ const NewConnectionForm = () => {
   const [form, setForm] = useState<INewConnectionForm>(defaultForm);
   const [errors, setErrors] = useState<INewConnectionErrors>({});
   const [alert, setAlert] = useState<boolean>(false);
+  const [alertMsg, setAlertMsg] = useState<string>('');
   const [connectionStringActive, setConnectionStringActive] =
     useState<boolean>(false);
+  const [isConnecting, setIsConnecting] = useState<boolean>(false);
 
   const navigate = useNavigate();
 
@@ -99,7 +102,7 @@ const NewConnectionForm = () => {
         newErrors.type = 'Please select a database type.';
       }
       if (!database) {
-        newErrors.type = 'Please type a database';
+        newErrors.database = 'Please type a database';
       }
       if (!address) {
         newErrors.address = 'Please type an address.';
@@ -151,22 +154,23 @@ const NewConnectionForm = () => {
     };
 
     try {
+      setIsConnecting(true);
+
       // creates the server connection in sqlite and connects to it
       await window.connections.ipcRenderer.create(connection);
 
-      // verify if server connection was established
-      const verified = await window.connections.ipcRenderer.verify();
-      if (!verified) {
-        setAlert(true);
-        return;
-      }
-      // show alert modal if unexpected error
-    } catch (e) {
+      // show alert modal if error on create
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    } catch (e: any) {
+      const error = parseErrorMessage(e.message);
+      setAlertMsg(error);
       setAlert(true);
+      setIsConnecting(false);
       return;
     }
 
     clearForm();
+    setIsConnecting(false);
     navigate('/execute');
   };
   return (
@@ -302,8 +306,8 @@ const NewConnectionForm = () => {
           </Form.Group>
           <Row>
             <Col>
-              <Button variant="primary" type="submit">
-                Connect
+              <Button variant="primary" type="submit" disabled={isConnecting}>
+                {isConnecting ? 'Connecting...' : 'Connect'}
               </Button>
             </Col>
             <Col>
@@ -321,6 +325,7 @@ const NewConnectionForm = () => {
       {alert && (
         <ServerConnectionErrorModal
           show={alert}
+          alertMsg={alertMsg}
           handleClose={() => setAlert(false)}
         />
       )}

--- a/src/renderer/components/recent_connections/ReadRow.tsx
+++ b/src/renderer/components/recent_connections/ReadRow.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import { Trash, PencilSquare } from 'react-bootstrap-icons';
 import { MouseEvent } from 'react';
 import { ConnectionModelType } from '../../../db/models/ConnectionModels';
@@ -18,15 +17,13 @@ const ReadRow = ({
   return (
     <tr key={value.id}>
       <td>
-        <Link to="/Execute">
-          <button
-            className="buttonSelect"
-            type="button"
-            onClick={() => handleSelect(value.id)}
-          >
-            {value.nickname}
-          </button>
-        </Link>
+        <button
+          className="buttonSelect"
+          type="button"
+          onClick={() => handleSelect(value.id)}
+        >
+          {value.nickname}
+        </button>
       </td>
       <td>{value.type}</td>
       <td>{value.address}</td>

--- a/src/renderer/components/recent_connections/Recent.tsx
+++ b/src/renderer/components/recent_connections/Recent.tsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ConnectionModelType } from '../../../db/models/ConnectionModels';
 import ServerConnectionErrorModal from '../modals/ServerConnectionErrorModal';
-import { formatConnectionString } from '../utils/helpers';
+import { formatConnectionString, parseErrorMessage } from '../utils/helpers';
 
 const RecentList = () => {
   const navigate = useNavigate();
 
   const [recent, setRecent] = useState<ConnectionModelType[]>();
   const [alert, setAlert] = useState<boolean>(false);
+  const [alertMsg, setAlertMsg] = useState<string>('');
 
   useEffect(() => {
     const fetchRecent = async () => {
@@ -21,7 +22,11 @@ const RecentList = () => {
   const handleClick = async (id: number) => {
     try {
       await window.connections.ipcRenderer.select(id);
-    } catch (e) {
+
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    } catch (e: any) {
+      const error = parseErrorMessage(e.message);
+      setAlertMsg(error);
       setAlert(true);
       return;
     }
@@ -51,6 +56,7 @@ const RecentList = () => {
       {alert && (
         <ServerConnectionErrorModal
           show={alert}
+          alertMsg={alertMsg}
           handleClose={() => setAlert(false)}
         />
       )}

--- a/src/renderer/components/utils/helpers.ts
+++ b/src/renderer/components/utils/helpers.ts
@@ -47,3 +47,7 @@ export function formatCleanupTables(rule: RuleModelType) {
   }
   return string;
 }
+
+export function parseErrorMessage(msg: string) {
+  return msg.slice(msg.slice(1, msg.length).search('Error: ') + 1, msg.length);
+}

--- a/src/renderer/components/utils/helpers.ts
+++ b/src/renderer/components/utils/helpers.ts
@@ -5,9 +5,11 @@ import { UnitTestType } from 'db/models/UnitTestModels';
 
 export function formatConnectionString(connection: ConnectionModelType) {
   const connectionString =
-    `${connection.type}://${connection.username}:` +
+    `${connection.type.toLowerCase()}://${connection.username}:` +
     `****` +
-    `@${connection.address}:${connection.port}`;
+    `@${connection.address}:${connection.port}/${connection.defaultDatabase}${
+      connection.ssl === true ? `?ssl=${connection.ssl}` : ''
+    }`;
 
   return connectionString;
 }

--- a/src/renderer/scss/Execute.scss
+++ b/src/renderer/scss/Execute.scss
@@ -86,13 +86,13 @@
   background-color: inherit;
   color: colors.$snow;
   border: none;
-  width: 100%;
   padding: 5px 0px;
 
   .recent-item-info {
     font-size: 12px;
     color: colors.$sand;
     overflow: hidden;
+    overflow-wrap: anywhere;
   }
   & span {
     display: block;

--- a/src/renderer/scss/Home.scss
+++ b/src/renderer/scss/Home.scss
@@ -38,13 +38,13 @@
           background-color: inherit;
           color: colors.$snow;
           border: none;
-          width: 100%;
           padding: 5px 0px;
 
           .recent-item-info {
             font-size: 12px;
             color: colors.$sand;
             overflow: hidden;
+            overflow-wrap: anywhere;
           }
           & span {
             display: block;


### PR DESCRIPTION
# Description

Modified backend to throw error message instead of default error
Modified Recent List, Recent Connections, New Connection Form to throw error modal with this message

Bug fixes:
- connection saved to database even if error occurs when creating 
- database error feedback not showing up if database not specified

NOTE:
- Timeout only happens after like 40 seconds. Is there a way to shorten this? I disable the connection button while waiting for server response, but this only works if the user stays on the page and doesn't go to home and back.

## Link to the issue you are closing

Fixes #190 

## Screenshot or other testing that you have completed

IP Address not permitted by firewall:
<img width="800" alt="Screen Shot 2022-11-20 at 12 38 06 PM" src="https://user-images.githubusercontent.com/29695042/202917757-405e9885-bb3f-49ab-a411-7964a3bb0af9.png">

Incorrect address:
<img width="800" alt="Screen Shot 2022-11-20 at 12 45 01 PM" src="https://user-images.githubusercontent.com/29695042/202917754-ec679ea1-b115-4c50-b831-4a0d717e2c75.png">

Timeout (happens if port is incorrect):
<img width="800" alt="Screen Shot 2022-11-20 at 12 44 45 PM" src="https://user-images.githubusercontent.com/29695042/202917756-bf2f000a-6117-4ed2-9519-9189e45f03b3.png">

Incorrect database
<img width="800" alt="Screen Shot 2022-11-20 at 12 45 15 PM" src="https://user-images.githubusercontent.com/29695042/202917753-a0a4d9eb-e816-4b18-8d08-e906c025ec0c.png">

Password/user combination is invalid:
<img width="800" alt="Screen Shot 2022-11-20 at 12 45 30 PM" src="https://user-images.githubusercontent.com/29695042/202917752-5753a25c-c452-4d98-a7b0-108d5232ab4f.png">

SSL mode is off:
<img width="800" alt="Screen Shot 2022-11-20 at 12 45 43 PM" src="https://user-images.githubusercontent.com/29695042/202917751-99086c6d-04ba-4fc3-9016-97a78ca15313.png">

Example Error Messages in Recent List / Recent Connections:

https://user-images.githubusercontent.com/29695042/202917759-698c411c-d9ba-438d-ae68-eea88c1a2166.mov


# Checklist:

- [x] ESLint passes
- [x] Prettier passes
- [x] Included comments where necessary
- [x] Updated README if needed
- [x] Verified that code runs and generates no errors/warnings
