### PR TITLE
Connection String SSL fix

### DIFF
--- a/src/db/entity/ConnectionEntity.ts
+++ b/src/db/entity/ConnectionEntity.ts
@@ -102,7 +102,7 @@ class ConnectionEntity {
         model.type,
         model.connectionConfig.connectionString
       );
-      const { username, password, endpoint } = fields;
+      const { username, password, endpoint, options } = fields;
       if (fields.hosts.length > 0) {
         Object.assign(this, {
           config: 'manual',
@@ -111,6 +111,7 @@ class ConnectionEntity {
           password,
           address: fields.hosts[0].host,
           port: fields.hosts[0].port,
+          ssl: options && options.ssl ? options.ssl === 'true' : false,
         });
       }
     }

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -31,7 +31,11 @@ export function parseConnectionString(
     scheme: type.toLowerCase(),
     hosts: [],
   });
-  return connectionStringParser.parse(cs);
+  let parseCs = cs;
+  if (cs.split('@').length - 1 > 1) {
+    parseCs = cs.replace('@', '%40');
+  }
+  return connectionStringParser.parse(parseCs);
 }
 
 export function setLog() {

--- a/src/renderer/components/new_connections/NewConnectionForm.tsx
+++ b/src/renderer/components/new_connections/NewConnectionForm.tsx
@@ -277,6 +277,13 @@ const NewConnectionForm = () => {
                   {errors.password}
                 </Form.Control.Feedback>
               </Form.Group>
+              <Form.Group className="mb-2" controlId="formBasicCheckbox">
+                <Form.Check
+                  onChange={() => setField('ssl', !form.ssl)}
+                  type="checkbox"
+                  label="SSL"
+                />
+              </Form.Group>
             </>
           )}
           {connectionStringActive && (
@@ -287,7 +294,7 @@ const NewConnectionForm = () => {
                 value={form.connectionString}
                 onChange={(e) => setField('connectionString', e.target.value)}
                 type="text"
-                placeholder="Ex: postgresql://username:password@address:port/db"
+                placeholder="Ex: postgresql://<username>:<password>@<address>:<port>/<database>?ssl=true"
                 isInvalid={!!errors.connectionString}
                 as="textarea"
                 rows={3}
@@ -297,13 +304,6 @@ const NewConnectionForm = () => {
               </Form.Control.Feedback>
             </Form.Group>
           )}
-          <Form.Group className="mb-2" controlId="formBasicCheckbox">
-            <Form.Check
-              onChange={() => setField('ssl', !form.ssl)}
-              type="checkbox"
-              label="SSL"
-            />
-          </Form.Group>
           <Row>
             <Col>
               <Button variant="primary" type="submit" disabled={isConnecting}>

--- a/src/renderer/components/utils/helpers.ts
+++ b/src/renderer/components/utils/helpers.ts
@@ -5,9 +5,11 @@ import { UnitTestType } from 'db/models/UnitTestModels';
 
 export function formatConnectionString(connection: ConnectionModelType) {
   const connectionString =
-    `${connection.type}://${connection.username}:` +
+    `${connection.type.toLowerCase()}://${connection.username}:` +
     `****` +
-    `@${connection.address}:${connection.port}`;
+    `@${connection.address}:${connection.port}/${connection.defaultDatabase}${
+      connection.ssl === true ? `?ssl=${connection.ssl}` : ''
+    }`;
 
   return connectionString;
 }

--- a/src/renderer/scss/Execute.scss
+++ b/src/renderer/scss/Execute.scss
@@ -86,13 +86,13 @@
   background-color: inherit;
   color: colors.$snow;
   border: none;
-  width: 100%;
   padding: 5px 0px;
 
   .recent-item-info {
     font-size: 12px;
     color: colors.$sand;
     overflow: hidden;
+    overflow-wrap: anywhere;
   }
   & span {
     display: block;

--- a/src/renderer/scss/Home.scss
+++ b/src/renderer/scss/Home.scss
@@ -38,13 +38,13 @@
           background-color: inherit;
           color: colors.$snow;
           border: none;
-          width: 100%;
           padding: 5px 0px;
 
           .recent-item-info {
             font-size: 12px;
             color: colors.$sand;
             overflow: hidden;
+            overflow-wrap: anywhere;
           }
           & span {
             display: block;


### PR DESCRIPTION
# Description

Connection Entity now sets ssl based on '?ssl=<value>' at the end of connection string. If nothing specified, it defaults to false, so ssl does not need to be set for local databases.

Also changed the string display to include default database and ssl if ssl = true.

Shows error messages as expected if fields are incorrect values.

## Link to the issue you are closing

Fixes #200 

## Screenshot or other testing that you have completed


https://user-images.githubusercontent.com/29695042/202924479-0f84146d-6a19-48b9-a16f-23101ca1f158.mov



# Checklist:

- [x] ESLint passes
- [x] Prettier passes
- [x] Included comments where necessary
- [x] Updated README if needed
- [x] Verified that code runs and generates no errors/warnings
