### PR TITLE
Toolbar Functionality

### DIFF
--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,12 +1,12 @@
 {
   "name": "DBTester",
   "version": "0.4.0",
-  "description": "A foundation for scalable desktop apps",
-  "license": "MIT",
+  "description": "A unit testing application for databases",
+  "license": "Apache 2.0",
   "author": {
-    "name": "Electron React Boilerplate Maintainers",
-    "email": "electronreactboilerplate@gmail.com",
-    "url": "https://github.com/electron-react-boilerplate"
+    "name": "Team Absolute Unit Testers",
+    "email": "randallwalker@kpmg.com",
+    "url": "https://github.com/JID-2111/JID-2111"
   },
   "main": "./dist/main/main.js",
   "scripts": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -72,6 +72,8 @@ const createWindow = async () => {
     show: false,
     width: 1024,
     height: 728,
+    minWidth: 1024,
+    minHeight: 728,
     icon: getAssetPath('icon.png'),
     webPreferences: {
       sandbox: false,

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -5,6 +5,7 @@ import {
   BrowserWindow,
   MenuItemConstructorOptions,
 } from 'electron';
+import ConnectionService from '../db/service/ConnectionService';
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
   selector?: string;
@@ -83,12 +84,57 @@ export default class MenuBuilder {
       ],
     };
     const subMenuFile: DarwinMenuItemConstructorOptions = {
-      label: 'File',
+      label: 'Connect',
       submenu: [
-        { label: 'New Connection', accelerator: 'Command+N', selector: '' },
-        { label: 'New Local DB', accelerator: 'Command+L', selector: '' },
+        {
+          label: 'New Connection',
+          accelerator: 'Command+N',
+          selector: '',
+          click: () => {
+            const service = new ConnectionService();
+            service.disconnect();
+            this.mainWindow.webContents.executeJavaScript(
+              "location.assign('#/newconnection');"
+            );
+          },
+        },
+        {
+          label: 'Recent Connections',
+          accelerator: 'Command+P',
+          selector: '',
+          click: () => {
+            const service = new ConnectionService();
+            service.disconnect();
+            this.mainWindow.webContents.executeJavaScript(
+              "location.assign('#/recentconnection');"
+            );
+          },
+        },
+        {
+          label: 'Disconnect',
+          accelerator: 'Command+D',
+          selector: '',
+          click: () => {
+            const service = new ConnectionService();
+            service.disconnect();
+            this.mainWindow.webContents.executeJavaScript(
+              "location.assign('#/');"
+            );
+          },
+        },
         { type: 'separator' },
-        { label: 'View History', accelerator: 'Command+H', selector: '' },
+        {
+          label: 'View History',
+          accelerator: 'Command+H',
+          selector: '',
+          click: () => {
+            const service = new ConnectionService();
+            service.disconnect();
+            this.mainWindow.webContents.executeJavaScript(
+              "location.assign('#/history');"
+            );
+          },
+        },
       ],
     };
     const subMenuEdit: DarwinMenuItemConstructorOptions = {
@@ -162,29 +208,26 @@ export default class MenuBuilder {
       label: 'Help',
       submenu: [
         {
-          label: 'Learn More',
-          click() {
-            shell.openExternal('https://electronjs.org');
-          },
-        },
-        {
-          label: 'Documentation',
+          label: 'Read Me',
+          accelerator: 'F1',
           click() {
             shell.openExternal(
-              'https://github.com/electron/electron/tree/main/docs#readme'
+              'https://github.com/JID-2111/JID-2111#stored-procedure-unit-tester'
             );
           },
         },
         {
-          label: 'Community Discussions',
+          label: 'Documentation',
+          accelerator: 'F2',
           click() {
-            shell.openExternal('https://www.electronjs.org/community');
+            // TODO - link to documentation
           },
         },
         {
           label: 'Search Issues',
+          accelerator: 'F3',
           click() {
-            shell.openExternal('https://github.com/electron/electron/issues');
+            shell.openExternal('https://github.com/JID-2111/JID-2111/issues');
           },
         },
       ],
@@ -209,17 +252,50 @@ export default class MenuBuilder {
   buildDefaultTemplate() {
     const templateDefault = [
       {
-        label: '&File',
+        label: '&Connect',
         submenu: [
           {
-            label: '&Open',
-            accelerator: 'Ctrl+O',
+            label: 'New Connection',
+            accelerator: 'Ctrl+N',
+            click: () => {
+              const service = new ConnectionService();
+              service.disconnect();
+              this.mainWindow.webContents.executeJavaScript(
+                "location.assign('#/newconnection');"
+              );
+            },
           },
           {
-            label: '&Close',
-            accelerator: 'Ctrl+W',
+            label: 'Recent Connections',
+            accelerator: 'Ctrl+P',
             click: () => {
-              this.mainWindow.close();
+              const service = new ConnectionService();
+              service.disconnect();
+              this.mainWindow.webContents.executeJavaScript(
+                "location.assign('#/recentconnection');"
+              );
+            },
+          },
+          {
+            label: 'Disconnect',
+            accelerator: 'Ctrl+D',
+            click: () => {
+              const service = new ConnectionService();
+              service.disconnect();
+              this.mainWindow.webContents.executeJavaScript(
+                "location.assign('#/');"
+              );
+            },
+          },
+          {
+            label: 'View History',
+            accelerator: 'Ctrl+H',
+            click: () => {
+              const service = new ConnectionService();
+              service.disconnect();
+              this.mainWindow.webContents.executeJavaScript(
+                "location.assign('#/history');"
+              );
             },
           },
         ],
@@ -272,27 +348,21 @@ export default class MenuBuilder {
           {
             label: 'Learn More',
             click() {
-              shell.openExternal('https://electronjs.org');
+              shell.openExternal(
+                'https://github.com/JID-2111/JID-2111#stored-procedure-unit-tester'
+              );
             },
           },
           {
             label: 'Documentation',
             click() {
-              shell.openExternal(
-                'https://github.com/electron/electron/tree/main/docs#readme'
-              );
-            },
-          },
-          {
-            label: 'Community Discussions',
-            click() {
-              shell.openExternal('https://www.electronjs.org/community');
+              // TODO - link to documentation
             },
           },
           {
             label: 'Search Issues',
             click() {
-              shell.openExternal('https://github.com/electron/electron/issues');
+              shell.openExternal('https://github.com/JID-2111/JID-2111/issues');
             },
           },
         ],


### PR DESCRIPTION
# Description

Can use toolbar + shortcuts:
- ⌘-N: New Connection Form
- ⌘-P: Recent Connections (R is for reload)
- ⌘-H: History
- ⌘-D: Disconnect (goes back to home)

Note: each one of these already disconnects from the database automatically so that we don't just travel from the execute page to one of these pages w/o dropping the connection

- works in packaged app
- also set min width / height of browser window
- updated author information in `release/package.json`

## Link to the issue you are closing

Fixes #50 

## Screenshot or other testing that you have completed


https://user-images.githubusercontent.com/29695042/203175539-f550867b-4122-4412-987a-779f64fc2d82.mp4



# Checklist:

- [ ] ESLint passes
- [ ] Prettier passes
- [ ] Included comments where necessary
- [ ] Updated README if needed
- [ ] Verified that code runs and generates no errors/warnings
